### PR TITLE
Add libpq-dev installer because if it doesn't exist, pip install pgcl…

### DIFF
--- a/system_global/install_postgresql_11.sh
+++ b/system_global/install_postgresql_11.sh
@@ -4,5 +4,6 @@ sudo echo "deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main" > /etc
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install -y postgresql
+sudo apt-get install -y libpq-dev
 
 exit 0


### PR DESCRIPTION
…i is failed.